### PR TITLE
Calling receipt() on a tx fails

### DIFF
--- a/packages/node/src/starknet/api.starknet.test.ts
+++ b/packages/node/src/starknet/api.starknet.test.ts
@@ -72,7 +72,7 @@ describe('Api.starknet', () => {
   });
 
   it('should have the ability to get receipts via transactions from all types', async () => {
-    console.log(await blockData.transactions[0].receipt?.());
+    expect(await blockData.transactions[0].receipt?.()).toBeDefined();
 
     expect(typeof blockData.transactions[0].receipt).toEqual('function');
     expect(typeof blockData.logs[0].transaction.receipt).toEqual('function');

--- a/packages/node/src/starknet/api.starknet.test.ts
+++ b/packages/node/src/starknet/api.starknet.test.ts
@@ -71,7 +71,9 @@ describe('Api.starknet', () => {
     expect(blockData.logs[0].transaction.callData.length).toBeGreaterThan(1);
   });
 
-  it('should have the ability to get receipts via transactions from all types', () => {
+  it('should have the ability to get receipts via transactions from all types', async () => {
+    console.log(await blockData.transactions[0].receipt?.());
+
     expect(typeof blockData.transactions[0].receipt).toEqual('function');
     expect(typeof blockData.logs[0].transaction.receipt).toEqual('function');
     expect(typeof blockData.logs[0].transaction.from).toEqual('string');

--- a/packages/node/src/starknet/api.starknet.ts
+++ b/packages/node/src/starknet/api.starknet.ts
@@ -222,6 +222,7 @@ export class StarknetApi implements ApiWrapper {
   async getTransactionReceipt(
     transactionHash: string,
   ): Promise<TransactionReceipt> {
+    console.log('hash', transactionHash);
     const receipt = await this.client.getTransactionReceipt(transactionHash);
     return formatReceipt(receipt);
   }
@@ -241,7 +242,9 @@ export class StarknetApi implements ApiWrapper {
           // Format done
           ...formatTransaction(tx, block, index),
           receipt: () =>
-            this.getTransactionReceipt(tx.hash).then((r) => formatReceipt(r)),
+            this.getTransactionReceipt(tx.transaction_hash).then((r) =>
+              formatReceipt(r),
+            ),
           logs: block.logs.filter(
             (l) => l.transactionHash === tx.transaction_hash,
           ),

--- a/packages/node/src/starknet/api.starknet.ts
+++ b/packages/node/src/starknet/api.starknet.ts
@@ -222,7 +222,6 @@ export class StarknetApi implements ApiWrapper {
   async getTransactionReceipt(
     transactionHash: string,
   ): Promise<TransactionReceipt> {
-    console.log('hash', transactionHash);
     const receipt = await this.client.getTransactionReceipt(transactionHash);
     return formatReceipt(receipt);
   }


### PR DESCRIPTION
# Description
Calling tx.receipt() triggers this error

`TypeError: Cannot convert undefined to a BigInt`

Fixes # (issue)

For some reason and after debugging, the property to call should be `tx.transaction_hash` and not `tx.hash`
Perhaps something is wrong else where in the code, but this change made it work.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
