### PR TITLE
Fix block finalization with devnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+.DS_Store

--- a/packages/common-starknet/CHANGELOG.md
+++ b/packages/common-starknet/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@subql/common` (#21)
 
 ## [1.0.2] - 2025-02-03
 ### Fixed

--- a/packages/common-starknet/package.json
+++ b/packages/common-starknet/package.json
@@ -14,7 +14,7 @@
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "dependencies": {
-    "@subql/common": "^5.2.2",
+    "@subql/common": "^5.4.0",
     "@subql/types-starknet": "workspace:*",
     "@typechain/starknet": "latest",
     "js-yaml": "^4.1.0",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@subql/common` (#21)
+
+### Fixed
+- Dictionary network family being invalid (#21)
+- Block finalization with devnets (#21)
 
 ## [5.7.2] - 2025-02-03
 ### Fixed

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -24,7 +24,7 @@
     "@nestjs/event-emitter": "^2.0.0",
     "@nestjs/platform-express": "^9.4.0",
     "@nestjs/schedule": "^3.0.1",
-    "@subql/common": "^5.2.2",
+    "@subql/common": "^5.4.0",
     "@subql/common-starknet": "workspace:*",
     "@subql/node-core": "16.1.1-1",
     "@subql/testing": "^2.2.2",

--- a/packages/node/src/indexer/dictionary/starknetDictionary.service.ts
+++ b/packages/node/src/indexer/dictionary/starknetDictionary.service.ts
@@ -4,15 +4,9 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { NETWORK_FAMILY } from '@subql/common';
-import {
-  NodeConfig,
-  DictionaryService,
-  ApiService,
-  getLogger,
-} from '@subql/node-core';
+import { NodeConfig, DictionaryService, getLogger } from '@subql/node-core';
 import { StarknetBlock, SubqlDatasource } from '@subql/types-starknet';
 import { SubqueryProject } from '../../configure/SubqueryProject';
-import { StarknetApiService } from '../../starknet';
 import { StarknetDictionaryV1 } from './v1';
 
 const logger = getLogger('dictionary');
@@ -26,7 +20,6 @@ export class StarknetDictionaryService extends DictionaryService<
     @Inject('ISubqueryProject') protected project: SubqueryProject,
     nodeConfig: NodeConfig,
     eventEmitter: EventEmitter2,
-    @Inject(ApiService) private apiService: StarknetApiService,
   ) {
     super(project.network.chainId, nodeConfig, eventEmitter);
   }
@@ -39,8 +32,7 @@ export class StarknetDictionaryService extends DictionaryService<
     }
 
     const dictionaryEndpoints = await this.getDictionaryEndpoints(
-      // @ts-ignore, todo: fix this after dictionary available
-      NETWORK_FAMILY.Starknet,
+      NETWORK_FAMILY.starknet,
       this.project.network,
     );
 

--- a/packages/node/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.ts
@@ -28,11 +28,9 @@ export class UnfinalizedBlocksService extends BaseUnfinalizedBlocksService<Block
   }
 
   protected async getFinalizedHead(): Promise<Header> {
-    const block = await this.apiService.api.getFinalizedBlock();
-    if (!block) {
-      return undefined as any;
-    }
-    return starknetBlockHeaderToHeader(block);
+    return starknetBlockHeaderToHeader(
+      await this.apiService.api.getFinalizedBlock(),
+    );
   }
 
   protected async getHeaderForHash(hash: string): Promise<Header> {

--- a/packages/node/src/indexer/unfinalizedBlocks.service.ts
+++ b/packages/node/src/indexer/unfinalizedBlocks.service.ts
@@ -28,9 +28,11 @@ export class UnfinalizedBlocksService extends BaseUnfinalizedBlocksService<Block
   }
 
   protected async getFinalizedHead(): Promise<Header> {
-    return starknetBlockHeaderToHeader(
-      await this.apiService.api.getFinalizedBlock(),
-    );
+    const block = await this.apiService.api.getFinalizedBlock();
+    if (!block) {
+      return undefined as any;
+    }
+    return starknetBlockHeaderToHeader(block);
   }
 
   protected async getHeaderForHash(hash: string): Promise<Header> {

--- a/packages/node/src/starknet/api.starknet.ts
+++ b/packages/node/src/starknet/api.starknet.ts
@@ -28,7 +28,10 @@ import {
   FunctionAbi,
 } from 'starknet';
 import { SPEC } from 'starknet-types-07';
-import { FinalizedBlockService } from './finalized.block.starknet';
+import {
+  FinalizedBlockService,
+  HEADER_WITH_STATUS,
+} from './finalized.block.starknet';
 import SafeStarknetProvider from './safe-api';
 import {
   hexEq,
@@ -164,7 +167,7 @@ export class StarknetApi implements ApiWrapper {
    * Get the latest block (with its header)
    * @returns {Promise<BLOCK_HEADER>}
    */
-  async getFinalizedBlock(): Promise<SPEC.BLOCK_WITH_RECEIPTS> {
+  async getFinalizedBlock(): Promise<HEADER_WITH_STATUS> {
     const block = await this.finalizedBlockService.getFinalizedBlock();
     return block;
   }

--- a/packages/node/src/starknet/finalized.block.starknet.spec.ts
+++ b/packages/node/src/starknet/finalized.block.starknet.spec.ts
@@ -36,6 +36,7 @@ const mockBlocks: Record<number | string, SPEC.BLOCK_WITH_RECEIPTS> = {
   3: createMockBlock(3, 'ACCEPTED_ON_L1'),
   2: createMockBlock(2, 'ACCEPTED_ON_L1'),
   1: createMockBlock(1, 'ACCEPTED_ON_L1'),
+  0: createMockBlock(0, 'ACCEPTED_ON_L1'),
 };
 
 const mockBlockService = {
@@ -63,7 +64,7 @@ describe('FinalizedBlockService', () => {
   it('should find the first ACCEPTED_ON_L1 block', async () => {
     const result = await (service as any).findFirstAcceptedOnL1();
     expect(result).toBeDefined();
-    expect(result?.block_number).toBe(1);
+    expect(result?.block_number).toBe(0);
     expect(result?.status).toBe('ACCEPTED_ON_L1');
   });
 
@@ -106,5 +107,28 @@ describe('FinalizedBlockService', () => {
     const result = await service.getFinalizedBlock();
     expect(result).toBeDefined();
     expect(result.block_number).toBe(8); // Now should update to block 8
+  });
+
+  // No blocks are accepted on L1 with devnets
+  it('works with devnet', async () => {
+    const blocks = {
+      latest: createMockBlock(4, 'ACCEPTED_ON_L2'),
+      4: createMockBlock(4, 'ACCEPTED_ON_L2'),
+      3: createMockBlock(3, 'ACCEPTED_ON_L2'),
+      2: createMockBlock(2, 'ACCEPTED_ON_L2'),
+      1: createMockBlock(1, 'ACCEPTED_ON_L2'),
+      0: createMockBlock(0, 'ACCEPTED_ON_L2'),
+    };
+
+    service = new FinalizedBlockService(
+      (hashOrNumber: number | string): any => {
+        return blocks[hashOrNumber];
+      },
+      mockLogger,
+    );
+
+    const result = await service.getFinalizedBlock();
+    expect(result).toBeDefined();
+    expect(result.block_number).toBe(0);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,7 +2884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/common-starknet@workspace:packages/common-starknet"
   dependencies:
-    "@subql/common": ^5.2.2
+    "@subql/common": ^5.4.0
     "@subql/types-starknet": "workspace:*"
     "@typechain/starknet": latest
     "@types/ejs": ^3.1.2
@@ -2921,11 +2921,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/common@npm:^5.2.2":
-  version: 5.2.2
-  resolution: "@subql/common@npm:5.2.2"
+"@subql/common@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "@subql/common@npm:5.4.0"
   dependencies:
-    "@subql/types-core": 2.0.0
+    "@subql/types-core": 2.0.1
     axios: ^0.28.0
     class-transformer: ^0.5.1
     class-validator: ^0.14.1
@@ -2934,7 +2934,7 @@ __metadata:
     reflect-metadata: ^0.1.14
     semver: ^7.6.3
     update-notifier: ^5.1.0
-  checksum: 91db322edee27860ef82a6a3a16413662543ed5f951720ddf9eb1617d9a172878cf0d5c89933edad03c6d3c22eee25c31799cd054fae934a4afbf606ac5ba3bd
+  checksum: 69bec37d8484c9b4526cfbe850c8fc50a3cf419f6d1a375e663dd2bd9d8d5a3f578292b96f583b850a8a3173437e70c171b3b77f18d61ad99f277c425c244728
   languageName: node
   linkType: hard
 
@@ -2981,7 +2981,7 @@ __metadata:
     "@nestjs/schedule": ^3.0.1
     "@nestjs/schematics": ^9.2.0
     "@nestjs/testing": ^9.4.0
-    "@subql/common": ^5.2.2
+    "@subql/common": ^5.4.0
     "@subql/common-starknet": "workspace:*"
     "@subql/node-core": 16.1.1-1
     "@subql/testing": ^2.2.2
@@ -3022,6 +3022,13 @@ __metadata:
   version: 2.0.0
   resolution: "@subql/types-core@npm:2.0.0"
   checksum: cb32c8f1eed13eabee65fb9dd0b4b64435ca18e820f640bd29a3e3a0d4c58692df1163fbc66c2dd29b52faab60b4bd895518c5aad63ec81ade5c250bf580619c
+  languageName: node
+  linkType: hard
+
+"@subql/types-core@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@subql/types-core@npm:2.0.1"
+  checksum: e9727804c720bbb55f90afc220940da5ef31c2a3c659d22c3756b9dc6e48ed50bf54858c66e6e9a380a6996c26452f8cd3c055531d6af80fa23569df2fecfea0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
Devnet never has finalized L1 blocks so an error was thrown. This fixes the error as well as some smaller code changes.

It also fixes the dictionary with the wrong network family.

Supersedes https://github.com/subquery/subql-starknet/pull/20

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
